### PR TITLE
COMP: Remove unused itkv3 header files

### DIFF
--- a/IGR3D_MABMIS_Testing.cxx
+++ b/IGR3D_MABMIS_Testing.cxx
@@ -42,8 +42,8 @@
 
 #include "itkHistogramMatchingImageFilter.h"
 #include "itkAddImageFilter.h"
-#include "itkDivideByConstantImageFilter.h"
-#include "itkMultiplyByConstantImageFilter.h"
+#include "itkDivideImageFilter.h"
+#include "itkMultiplyImageFilter.h"
 #include "itkWarpVectorImageFilter.h"
 #include "itkInverseDeformationFieldImageFilter.h"
 

--- a/itkMABMISDeformationFieldFilter.h
+++ b/itkMABMISDeformationFieldFilter.h
@@ -11,8 +11,8 @@
 #include "itkImage.h"
 #include "itkWarpImageFilter.h"
 #include "itkAddImageFilter.h"
-#include "itkDivideByConstantImageFilter.h"
-#include "itkMultiplyByConstantImageFilter.h"
+#include "itkDivideImageFilter.h"
+#include "itkMultiplyImageFilter.h"
 
 // interpolator
 #include "itkLinearInterpolateImageFunction.h"
@@ -60,9 +60,9 @@ public:
 
   typedef itk::WarpVectorImageFilter<DeformationFieldType, DeformationFieldType,
                                      DeformationFieldType>         WarpVectorFilterType;
-  typedef itk::MultiplyByConstantImageFilter<DeformationFieldType, float,
+  typedef itk::MultiplyImageFilter<DeformationFieldType, float,
                                              DeformationFieldType> MultiplyDeformationFieldFilterType;
-  typedef itk::DivideByConstantImageFilter<DeformationFieldType, float,
+  typedef itk::DivideImageFilter<DeformationFieldType, float,
                                            DeformationFieldType>   DivideDeformationFieldFilterType;
   typedef itk::AddImageFilter<DeformationFieldType, DeformationFieldType,
                               DeformationFieldType>                AddImageFilterType;


### PR DESCRIPTION
The class itkAdd(DivideByConstantImageFilter is only available
ITKv3 compatibility is on. The upcoming Slicer release will turn the
ITKv3 compatibility off.